### PR TITLE
Add auto-upgrade workflow

### DIFF
--- a/.github/workflows/upgrade_trunk.yaml
+++ b/.github/workflows/upgrade_trunk.yaml
@@ -4,6 +4,8 @@ on:
     # Weekly at midnight M/W/F morning
     - cron: 0 8 * * 1,3,5
   workflow_dispatch: {}
+  # TODO: TYLER REMOVE THE PR PART
+  pull_request: {}
 
 permissions: read-all
 

--- a/.github/workflows/upgrade_trunk.yaml
+++ b/.github/workflows/upgrade_trunk.yaml
@@ -4,8 +4,6 @@ on:
     # Weekly at midnight M/F morning
     - cron: 0 8 * * 1,5
   workflow_dispatch: {}
-  # TODO: TYLER REMOVE THE PR PART
-  pull_request: {}
 
 permissions: read-all
 
@@ -28,7 +26,7 @@ jobs:
           private_key: ${{ secrets.TRUNK_OPEN_PR_APP_PRIVATE_KEY }}
 
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@49e50397aa3388a778d91b3b0c49aaf184983063
+        uses: trunk-io/trunk-action/upgrade@98224163e8e5d90318f26bca1eeb605f8ce8781b
         with:
           add-paths: plugin.yaml
           arguments: --apply-to=plugin.yaml -n

--- a/.github/workflows/upgrade_trunk.yaml
+++ b/.github/workflows/upgrade_trunk.yaml
@@ -1,8 +1,8 @@
 name: Weekly
 on:
   schedule:
-    # Weekly at midnight M/W/F morning
-    - cron: 0 8 * * 1,3,5
+    # Weekly at midnight M/F morning
+    - cron: 0 8 * * 1,5
   workflow_dispatch: {}
   # TODO: TYLER REMOVE THE PR PART
   pull_request: {}

--- a/.github/workflows/upgrade_trunk.yaml
+++ b/.github/workflows/upgrade_trunk.yaml
@@ -28,7 +28,7 @@ jobs:
           private_key: ${{ secrets.TRUNK_OPEN_PR_APP_PRIVATE_KEY }}
 
       - name: Trunk Upgrade
-        uses: trunk-io/action/upgrade@e5f1a3f123a2440f9cd28e036495a1c1f2a20568 # v1.1.1
+        uses: trunk-io/trunk-action/upgrade@e5f1a3f123a2440f9cd28e036495a1c1f2a20568 # v1.1.1
         with:
           arguments: --apply-to=plugin.yaml -n
           github-token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/upgrade_trunk.yaml
+++ b/.github/workflows/upgrade_trunk.yaml
@@ -28,8 +28,9 @@ jobs:
           private_key: ${{ secrets.TRUNK_OPEN_PR_APP_PRIVATE_KEY }}
 
       - name: Trunk Upgrade
-        uses: trunk-io/trunk-action/upgrade@e5f1a3f123a2440f9cd28e036495a1c1f2a20568 # v1.1.1
+        uses: trunk-io/trunk-action/upgrade@49e50397aa3388a778d91b3b0c49aaf184983063
         with:
+          add-paths: plugin.yaml
           arguments: --apply-to=plugin.yaml -n
           github-token: ${{ steps.generate-token.outputs.token }}
           reviewers: TylerJang27

--- a/.github/workflows/upgrade_trunk.yaml
+++ b/.github/workflows/upgrade_trunk.yaml
@@ -1,0 +1,33 @@
+name: Weekly
+on:
+  schedule:
+    # Weekly at midnight M/W/F morning
+    - cron: 0 8 * * 1,3,5
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  trunk_upgrade:
+    name: Upgrade Trunk
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # For trunk to create PRs
+      pull-requests: write # For trunk to create PRs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Create App Token for TrunkBuild App (Internal)
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TRUNK_OPEN_PR_APP_ID }}
+          private_key: ${{ secrets.TRUNK_OPEN_PR_APP_PRIVATE_KEY }}
+
+      - name: Trunk Upgrade
+        uses: trunk-io/action/upgrade@e5f1a3f123a2440f9cd28e036495a1c1f2a20568 # v1.1.1
+        with:
+          arguments: --apply-to=plugin.yaml -n
+          github-token: ${{ steps.generate-token.outputs.token }}
+          reviewers: TylerJang27

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,7 +4,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.15
+      ref: v0.0.17
       uri: https://github.com/trunk-io/plugins
     - id: configs
       local: .


### PR DESCRIPTION
This will keep our linters up to date, although we'll still have to approve the PRs and make manual weekly-ish releases. We might also have to occasionally bump the plugin ref in the `.trunk/trunk.yaml` in order to keep _this_ repo up to date and passing.

[Demonstrated successful run](https://github.com/trunk-io/configs/actions/runs/5204635588/jobs/9389113298?pr=3)