### PR TITLE
Remove python docstrings rules

### DIFF
--- a/configs/ruff.toml
+++ b/configs/ruff.toml
@@ -1,5 +1,5 @@
 # Generic, formatter-friendly config.
-select = ["B", "D3", "D4", "E", "F"]
+select = ["B", "D3", "E", "F"]
 
 # Never enforce `E501` (line length violations). This should be handled by formatters.
 ignore = ["E501"]


### PR DESCRIPTION
Modify the ruff config. See https://github.com/trunk-io/plugins/pull/483