### PR TITLE
Fix stylelint packages

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -6,3 +6,4 @@
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,5 +10,7 @@ plugins:
     - id: configs
       local: .
 # see plugin.yaml for enabled linters
-# lint:
+lint:
+  disabled:
+    - eslint
 #   enabled: []

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,11 +1,11 @@
 version: 0.1
 cli:
-  version: 1.18.1
+  version: 1.19.0
 plugins:
   sources:
     - id: trunk
       uri: https://github.com/trunk-io/plugins
-      ref: v1.4.0
+      ref: v1.4.2
 
     - id: configs
       local: .

--- a/configs/.stylelintrc.js
+++ b/configs/.stylelintrc.js
@@ -1,0 +1,4 @@
+/** @type {import('stylelint').Config} */
+module.exports = {
+  extends: ["stylelint-config-standard-scss", "stylelint-config-clean-order"],
+};

--- a/configs/.stylelintrc.yaml
+++ b/configs/.stylelintrc.yaml
@@ -1,4 +1,3 @@
 extends:
   - stylelint-config-standard-scss
-  - stylelint-config-prettier
   - stylelint-config-clean-order

--- a/configs/.stylelintrc.yaml
+++ b/configs/.stylelintrc.yaml
@@ -1,3 +1,0 @@
-extends:
-  - stylelint-config-standard-scss
-  - stylelint-config-clean-order

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -77,6 +77,7 @@ lint:
     - stylelint@16.1.0:
         packages:
           - stylelint-config-standard-scss@13.0.0
+          - stylelint-config-clean-order@5.4.0
     - svgo@3.2.0
     - taplo@0.8.1
     - terrascan@1.18.11

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -74,7 +74,9 @@ lint:
     - shfmt@3.6.0
     - sort-package-json@2.6.0
     - sql-formatter@15.0.2
-    - stylelint@16.1.0
+    - stylelint@16.1.0:
+        packages:
+          - stylelint-config-standard-scss@13.0.0
     - svgo@3.2.0
     - taplo@0.8.1
     - terrascan@1.18.11

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -100,7 +100,7 @@ lint:
         - configs/rustfmt.toml
         - configs/.shellcheckrc
         - configs/.sqlfluff
-        - configs/.stylelintrc.yaml
+        - configs/.stylelintrc.js
         - configs/svgo.config.js
         - configs/.yamllint.yaml
 


### PR DESCRIPTION
The stylelint config was referencing a package that wasn't being installed.

Also upgrades the CLI.