### PR TITLE
Rev configs to latest plugins

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,11 +1,11 @@
 version: 0.1
 cli:
-  version: 1.19.0
+  version: 1.20.0
 plugins:
   sources:
     - id: trunk
       uri: https://github.com/trunk-io/plugins
-      ref: v1.4.2
+      ref: v1.4.3
 
     - id: configs
       local: .

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -10,33 +10,6 @@ runtimes:
     - ruby@3.1.4
 
 lint:
-  downloads:
-    - name: trunk-toolbox
-      # Our own internal alpha linter
-      downloads:
-        - os:
-            linux: unknown-linux-gnu
-            macos: apple-darwin
-          cpu:
-            x86_64: x86_64
-            arm_64: aarch64
-          url: https://github.com/trunk-io/toolbox/releases/download/${version}/trunk-toolbox-${version}-${cpu}-${os}.tar.gz
-
-  definitions:
-    - name: trunk-toolbox
-      download: trunk-toolbox
-      files: [ALL]
-      commands:
-        - output: sarif
-          run: trunk-toolbox --upstream ${upstream-ref}
-          success_codes: [0]
-          read_output_from: stdout
-          disable_upstream: true
-          target: .
-      environment:
-        - name: PATH
-          list: ["${linter}"]
-
   # By sourcing this plugin, repos will enable these linters
   enabled:
     - actionlint@1.6.26
@@ -83,7 +56,7 @@ lint:
     - terrascan@1.18.11
     - trivy@0.49.0
     - trufflehog@3.66.3
-    - trunk-toolbox@0.0.1
+    - trunk-toolbox@0.2.0
     - yamllint@1.33.0
 
   # Sourcing repos will have these configs available to applicable linters


### PR DESCRIPTION
1. Pin to latest plugins release 1.4.3
2. Toolbox is now defined in plugins repo / so remove local definition of the tool from configs.