### PR TITLE
(Chore): Enable grpcui tool

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,11 +1,11 @@
 version: 0.1
 cli:
-  version: 1.22.2
+  version: 1.22.6
 plugins:
   sources:
     - id: trunk
       uri: https://github.com/trunk-io/plugins
-      ref: v1.6.2
+      ref: v1.6.4
 
     - id: configs
       local: .

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -90,4 +90,5 @@ actions:
 tools:
   enabled:
     - gh@2.58.0
+    - grpcui@1.4.1
     - gt@1.4.6


### PR DESCRIPTION
Enabled by default for easy use. When this is released and monorepo is upgraded, it will auto-have this enabled