### PR TITLE
Update default SVGO configuration file to an ESM Module

### DIFF
--- a/configs/svgo.config.mjs
+++ b/configs/svgo.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: [
     {
       name: "preset-default",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -75,7 +75,7 @@ lint:
         - configs/.shellcheckrc
         - configs/.sqlfluff
         - configs/.stylelintrc.js
-        - configs/svgo.config.js
+        - configs/svgo.config.mjs
         - configs/.yamllint.yaml
 
 # By sourcing this plugin, repos will enable these actions


### PR DESCRIPTION
Updating the default SVGO configuration to an ES Module helps future-proof it and prevent issues with NPM projects set to `"type": "module"`.